### PR TITLE
Clean up role template examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,3 @@ This template has no role dependencies.
 GPL-3.0: <https://opensource.org/licenses/GPL-3.0>
 
 Copyright (c) Chris Ruettimann <chris@bitbull.ch>
-
-## Support
-
-Many thanks to all Open Source supporters. If you use this construct for
-productive work, please consider a donation to
-[Stiftung Buehl](https://www.stiftung-buehl.ch/ueber-uns/spenden).

--- a/README.md
+++ b/README.md
@@ -1,69 +1,54 @@
-# BITBULL ANSIBLE ROLE TEMPLATE
+# Bitbull Ansible Role Template
 
-## WHY
-When Red Hat officially started supporting Ansible, I had a lot of fun immersing myself    
-in this really new concept of automation and keeping my knowledge up to date.   
+## Why
 
-A must for every efficient Linux consultant!   
+This repository is a reusable Ansible role template for roles that need clear,
+dynamic OS-specific task dispatching while staying compatible with AWX.
 
-Just like GitHub repos, which at the beginning was the desired solution to a long worn problem,    
-with its excessive use it quickly became clear that management and maintenance are the    
-factors that determine the expense of these resources you have to spend in the future.   
+The template is designed to make role maintenance easier by keeping task order
+stable and selecting the best matching implementation from Ansible facts.
 
-I have always been of the opinion that what cannot be maintained in Operations has been developed incorrectly.     
-And I am constantly trying to do justice to this.    
+## How it works
 
-For this purpose I have developed an Ansible role template, which is mandatory:    
-* Clear
-* Unambiguous
-* Dynamic   
+The dispatcher in `tasks/main.yml`:
 
-which in turn reduces:    
-* Error
-* Familiarization
-* Maintenance
+1. Sets `ansible_distribution_combine` to `rhelAll` for RHEL-like distributions
+   (`AlmaLinux`, `Rocky`, `RedHat`) and to `dummy` for all other systems.
+2. Finds all task files below `tasks/` whose filename matches
+   `^[0-9]{2}_.*.yml$`.
+3. Deduplicates task basenames and sorts them by filename.
+4. Includes each basename once through `tasks/include-file.yml`.
 
-This template concept, which I searched on the internet and did not find is foremost compatible with the current version of AWX.    
-(upstream project for Ansible Tower)
+For every task basename, `tasks/include-file.yml` uses the first existing file
+from this order:
 
-## HOW IT WORKS
-* Create a deduplicated list of task files
-* Reorder them by numbers
-* Run tasks by first match with the ansible_facts of the target machine (```include-file.yml```)
-  * ```{{  ansible_distribution_custom }}-{{ ansible_distribution_version }}```
-    * rhelAll-8.4
-  * ```{{ ansible_distribution_custom }}-{{ ansible_distribution_major_version }}```
-    * rhelAll-8
-  * ```{{ ansible_distribution_custom }}```
-    * rhelAll
-  * ```{{ ansible_distribution }}-{{ ansible_distribution_version }}```
-    * Rocky-8.4
-    * Ubuntu-24.04
-  * ```{{ ansible_distribution }}-{{ ansible_distribution_major_version }}```
-    * AlmaLinux-8
-    * Ubuntu-20
-  * ```{{ ansible_distribution }}```
-    * Rocky
-    * Ubuntu
-  * ```{{ ansible_os_family }}```
-    * RedHat
-    * Debian
-  * ```shared```
-    * This is the fallback, if noting above matches
-
-* Note, since RockyLinux and AlmaLinux are RHEL clones that work almost similar, we needed just one os folder for both
-  * If you need tasks that work for Alma and Rocky, create a folder named ```rhelAll``` in ```tasks``` folder
-    * It get catched like the var ```{{ ansible_distribution }}``` above
-
-You can look ito the role directory, it will be clear why and how to use it.   
-
-To get an overview, just look up the file names:
+```text
+tasks/{{ ansible_distribution }}-{{ ansible_distribution_version }}/<task>.yml
+tasks/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}/<task>.yml
+tasks/{{ ansible_distribution }}/<task>.yml
+tasks/{{ ansible_distribution_combine }}-{{ ansible_distribution_version }}/<task>.yml
+tasks/{{ ansible_distribution_combine }}-{{ ansible_distribution_major_version }}/<task>.yml
+tasks/{{ ansible_distribution_combine }}/<task>.yml
+tasks/{{ ansible_os_family }}/<task>.yml
+tasks/shared/<task>.yml
 ```
-$ find tasks -type f -name '*.yml' #modified view
 
+Examples:
+
+- `tasks/Rocky-9/10_prep.yml` overrides `tasks/rhelAll/10_prep.yml` and
+  `tasks/shared/10_prep.yml` on Rocky Linux 9 hosts.
+- `tasks/rhelAll/20_setup.yml` can be used for common AlmaLinux, Rocky Linux,
+  and Red Hat Enterprise Linux logic.
+- `tasks/Ubuntu/20_setup.yml` can be used for Ubuntu-specific logic.
+- `tasks/shared/30_post.yml` is the final fallback when no OS-specific file
+  exists for the same basename.
+
+## Example layout
+
+```text
 tasks/shared/01_run_on_all_systems.yml
 
-tasks/Rocky-7/10_prep.yml
+tasks/Rocky-9/10_prep.yml
 tasks/shared/10_prep.yml
 
 tasks/Rocky-8/20_setup.yml
@@ -73,53 +58,53 @@ tasks/Rocky-8/30_post.yml
 tasks/shared/30_post.yml
 ```
 
-## Drawback of this solution
-Including of task-files, depending on given ansible-facts, has to get created in blocks statements within the task files itself.
+Numeric prefixes define execution order. The same basename can exist in multiple
+OS folders; only the first matching implementation is included for a host.
 
-## One final word
-Many thanks to all supporters of OpenSource products,    
-only by sharing our solutions we could get this far!   
-If you use this construct for your productive work,    
-we would appreciate a donation to the [Stifung Buehl](https://www.stiftung-buehl.ch/ueber-uns/spenden).   
-All our know-how is OpenSource and your donation enables    
-children and young people with special needs to find a place in life.   
+## Drawback
 
-Chris Ruettimann <chris@bitbull.ch>
+Conditional grouping still has to be implemented inside the selected task file
+when several tasks need to be wrapped in the same `block`.
 
-# <ROLENAME>
+## Role skeleton
 
-Installation with ansible-galaxy:
+After copying this template for a real role, update at least:
 
-``` bash
+- `meta/main.yml` (`role_name`, description, supported platforms)
+- `defaults/main.yml` (user-overridable variables)
+- `vars/main.yml` (fixed internal variables)
+- `tasks/*` (replace the example debug tasks)
+- `handlers/main.yml` (replace the example service handler)
+- `tests/test.yml` (use the final Galaxy role name)
+
+## Installation
+
+```bash
 ansible-galaxy install joe-speedboat.template
 ```
 
-## Requirements xxx
+## Requirements
 
-* Currently tested with Rocky 9 
-* Ansible 2.9 or higher is required for this Ansible Role
+- Ansible 2.9 or higher
+- A supported Linux distribution for the role generated from this template
 
-* Operating System: Rocky 9
-* OS Disk: min 00 GB
-* Data Disk: min 00 GB
-* CPU: min 00   
-* Memory: min 00 GB   
+## Role variables
 
-
-
-Role Variables
---------------
-
-Variables are speaking or documented in defaults/main.yml   
-One variable is mandatory: var1xxx
-
+Document user-overridable variables in `defaults/main.yml`. Keep fixed internal
+maps and constants in `vars/main.yml`.
 
 ## Dependencies
 
-This Ansilbe Role has no dependencies to other Ansilbe Roles
+This template has no role dependencies.
 
-License
--------
-https://opensource.org/licenses/GPL-3.0    
+## License
+
+GPL-3.0: <https://opensource.org/licenses/GPL-3.0>
+
 Copyright (c) Chris Ruettimann <chris@bitbull.ch>
 
+## Support
+
+Many thanks to all Open Source supporters. If you use this construct for
+productive work, please consider a donation to
+[Stiftung Buehl](https://www.stiftung-buehl.ch/ueber-uns/spenden).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # defaults/main.yml
 ---
-# Here belong all variables, that can be changed by a vars-file,
-# a playbook or a include.
+# Put variables here when users may override them from inventory, playbooks,
+# AWX surveys, or extra-vars.
 
 mandatory_default_var1xxx: playbook-will-fail-without-this-var
 default_var2_xxx: this_is_defined_in_defaults_folder

--- a/files/README.md
+++ b/files/README.md
@@ -1,1 +1,1 @@
-Add files here, which can be copied 1-1 without changes
+Put static files here when they can be copied unchanged.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,9 @@
 # handlers/main.yml
 ---
-# Here belong all actions like service-restart,
-# config-file loads, etc. that will be started
-# if a change on a task was made
+# Put restart, reload, and other notified actions here.
 
-- name: restart <SERVICE>
-  service:
+- name: Restart <SERVICE>
+  ansible.builtin.service:
     name: <SERVICE>
     state: restarted
-
 ...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,20 +1,19 @@
 # meta/main.yml
 ---
-# Change as needed
+# Change as needed.
 galaxy_info:
   author: Chris Ruettimann
   role_name: template
-#  namespace: joe-speedboat
+  # namespace: joe-speedboat
   description: Bitbull Template Ansible Role
-  min_ansible_version: 2.9
+  min_ansible_version: '2.9'
   license: GPLv3
   platforms:
-  - name: EL
-    versions:
-    - 7
-    - 8
+    - name: EL
+      versions:
+        - '7'
+        - '8'
   galaxy_tags: []
 
-# We don't use dependencies in here anymore
 dependencies: []
 ...

--- a/tasks/Rocky-8/20_setup.yml
+++ b/tasks/Rocky-8/20_setup.yml
@@ -1,3 +1,5 @@
 ---
-- debug: msg="This is an example task file for tasks/Rocky-8/20_setup.yml"
+- name: Show Rocky 8 setup example
+  ansible.builtin.debug:
+    msg: This is an example task file for tasks/Rocky-8/20_setup.yml
 ...

--- a/tasks/Rocky-8/30_post.yml
+++ b/tasks/Rocky-8/30_post.yml
@@ -1,3 +1,5 @@
 ---
-- debug: msg="This is an example task file for tasks/Rocky-8/30_post.yml"
+- name: Show Rocky 8 post example
+  ansible.builtin.debug:
+    msg: This is an example task file for tasks/Rocky-8/30_post.yml
 ...

--- a/tasks/Rocky-9/10_prep.yml
+++ b/tasks/Rocky-9/10_prep.yml
@@ -1,3 +1,5 @@
 ---
-- debug: msg="This is an example task file for tasks/Rocky-9/10_prep.yml"
+- name: Show Rocky 9 prep example
+  ansible.builtin.debug:
+    msg: This is an example task file for tasks/Rocky-9/10_prep.yml
 ...

--- a/tasks/include-file.yml
+++ b/tasks/include-file.yml
@@ -1,28 +1,28 @@
 ---
-- name: include {{ include_file_name }}
-  include_tasks: '{{ include_file_path }}'
+- name: Include {{ include_file_name }}
+  ansible.builtin.include_tasks: "{{ include_file_path }}"
   with_first_found:
     - files:
-        # order example for: rocky 9  +  RHEL 9
+        # Order example for Rocky 9 / RHEL 9:
         # tasks/Rocky-9.0                tasks/RedHat-9.0
         # tasks/Rocky-9                  tasks/RedHat-9
         # tasks/Rocky                    tasks/RedHat
         # tasks/rhelAll-9.0              tasks/rhelAll-9.0
         # tasks/rhelAll-9                tasks/rhelAll-9
         # tasks/rhelAll                  tasks/rhelAll
-        # tasks/RedHat                   tasks/RedHat -> only useful for debianX
+        # tasks/RedHat                   tasks/RedHat -> only useful for Debian-like fallbacks
         # tasks/shared                   tasks/shared
-        # regular facts will get catched first, eg.: Rocky-9 or RedHat-9 or AlmaLinux9
-        - "{{ vars['task_dir_' + role_name|split('.')|last] }}/{{ ansible_distribution }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
-        - "{{ vars['task_dir_' + role_name|split('.')|last] }}/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
-        - "{{ vars['task_dir_' + role_name|split('.')|last] }}/{{ ansible_distribution }}/{{ include_file_name }}"
-        # ansible_distribution_combine var will cover Rocky-9 and RedHat-9 and AlmaLinux9
-        - "{{ vars['task_dir_' + role_name|split('.')|last] }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
-        - "{{ vars['task_dir_' + role_name|split('.')|last] }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
-        - "{{ vars['task_dir_' + role_name|split('.')|last] }}/{{ ansible_distribution_combine }}/{{ include_file_name }}"
-        # if all fails, we fallback to os family
-        - "{{ vars['task_dir_' + role_name|split('.')|last] }}/{{ ansible_os_family }}/{{ include_file_name }}"
-        - "{{ vars['task_dir_' + role_name|split('.')|last] }}/shared/{{ include_file_name }}"
+        # Regular facts are matched first, e.g. Rocky-9, RedHat-9, or AlmaLinux-9.
+        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
+        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
+        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution }}/{{ include_file_name }}"
+        # ansible_distribution_combine covers Rocky, RedHat, and AlmaLinux with one rhelAll folder.
+        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
+        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
+        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution_combine }}/{{ include_file_name }}"
+        # If all OS-specific matches fail, fall back to OS family and then shared tasks.
+        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_os_family }}/{{ include_file_name }}"
+        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/shared/{{ include_file_name }}"
   loop_control:
     loop_var: include_file_path
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,99 +2,90 @@
 ---
 ######## START: Get playbooks to run ########
 
-- name: Create rhelAll fact fallback
-  set_fact:
-    ansible_distribution_combine: dummy
+- name: Create combined distribution fact for RHEL-compatible systems
+  ansible.builtin.set_fact:
+    ansible_distribution_combine: "{{ 'rhelAll' if ansible_distribution in ['AlmaLinux', 'Rocky', 'RedHat'] else 'dummy' }}"
 
-- name: Create rhelAll fact, useful when AlmaLinux, Rocky, RHEL, ... all use the same Ansible code base
-  set_fact:
-    ansible_distribution_combine: rhelAll
-  when: >
-    ansible_distribution == "AlmaLinux" or
-    ansible_distribution == "Rocky" or
-    ansible_distribution == "RedHat"
-
-- name: fix ansible_python_interpreter, for Rocky and AlmaLinux, see lib/ansible/config/base.yml
+- name: Fix ansible_python_interpreter for Rocky and AlmaLinux, see lib/ansible/config/base.yml
   block:
-  - name: rhelClone v9
-    set_fact:
-      ansible_python_interpreter: /usr/bin/python3
-    when: ansible_distribution_major_version|int == 9
-  when: >
-    ansible_distribution == "AlmaLinux" or
-    ansible_distribution == "Rocky"
+    - name: rhelClone v9
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: /usr/bin/python3
+      when: ansible_distribution_major_version | int == 9
+  when: ansible_distribution in ['AlmaLinux', 'Rocky']
 
-- set_fact:
+- name: Initialize include file list
+  ansible.builtin.set_fact:
     include_file_names: []
 
-- name: find role directory  (awx aware)
-  find:
-    paths: 
-    - /runner/requirements_roles
-    - "{{ lookup('env', 'PWD') }}/roles/{{role_path|basename}}/tasks"
-    - "{{ lookup('env', 'HOME') }}/.ansible/roles/{{role_path|basename}}/tasks"
-    - "/usr/share/ansible/roles/{{role_path|basename}}/tasks"
-    - "/etc/ansible/roles/{{role_path|basename}}/tasks"
-    - "/runner/project/roles/{{role_path|basename}}/tasks"
-    - "/runner/requirements_roles/{{role_path|basename}}/tasks"
-    recurse: no
+- name: Find role directory (AWX aware)
+  ansible.builtin.find:
+    paths:
+      - /runner/requirements_roles
+      - "{{ lookup('env', 'PWD') }}/roles/{{ role_path | basename }}/tasks"
+      - "{{ lookup('env', 'HOME') }}/.ansible/roles/{{ role_path | basename }}/tasks"
+      - "/usr/share/ansible/roles/{{ role_path | basename }}/tasks"
+      - "/etc/ansible/roles/{{ role_path | basename }}/tasks"
+      - "/runner/project/roles/{{ role_path | basename }}/tasks"
+      - "/runner/requirements_roles/{{ role_path | basename }}/tasks"
+    recurse: false
     depth: 1
-    file_type: file 
-    use_regex: no 
+    file_type: file
+    use_regex: false
     patterns: main.yml
   delegate_to: localhost
-  become: no
-  run_once: True
+  become: false
+  run_once: true
   register: found_task_dirs
-  no_log: True
+  no_log: true
 
-- name: show tasks directory var
-  debug:
-    msg: "{{ 'task_dir_' + role_name|split('.')|last }}: {{ found_task_dirs.files[0].path|dirname }}"
+- name: Show tasks directory var
+  ansible.builtin.debug:
+    msg: "{{ 'task_dir_' + role_name | split('.') | last }}: {{ found_task_dirs.files[0].path | dirname }}"
     verbosity: 1
 
-- name: define tasks directory
-  set_fact:
-    "{{ 'task_dir_' + role_name|split('.')|last }}": "{{ found_task_dirs.files[0].path|dirname }}"
+- name: Define tasks directory
+  ansible.builtin.set_fact:
+    "{{ 'task_dir_' + role_name | split('.') | last }}": "{{ found_task_dirs.files[0].path | dirname }}"
 
-- name: find all task files with numeric pattern
-  find:
-    paths: "{{ vars['task_dir_' + role_name|split('.')|last] }}"
-    recurse: yes 
-    depth: 2 
-    file_type: file 
-    use_regex: yes 
+- name: Find all task files with numeric pattern
+  ansible.builtin.find:
+    paths: "{{ vars['task_dir_' + role_name | split('.') | last] }}"
+    recurse: true
+    depth: 2
+    file_type: file
+    use_regex: true
     patterns: ['^[0-9]{2}_.*.yml$']
   delegate_to: localhost
-  become: no
-  run_once: True
+  become: false
+  run_once: true
   register: found_playbooks
 
-- name: trim all playbook paths
-  set_fact:
-    include_file_names: "{{ include_file_names + [ plays.path | regex_replace('.*/', '') ] }}"
+- name: Trim all playbook paths
+  ansible.builtin.set_fact:
+    include_file_names: "{{ include_file_names + [plays.path | regex_replace('.*/', '')] }}"
   loop: "{{ found_playbooks.files }}"
   loop_control:
     loop_var: plays
-  no_log: True
+  no_log: true
 
-- name: sort and uniq
-  set_fact: 
+- name: Sort and deduplicate playbooks
+  ansible.builtin.set_fact:
     include_file_names: "{{ include_file_names | unique | sort }}"
 
-- name: show playbooks
-  debug:
-    msg: "include_file_names: {{ include_file_names | unique | sort }}"
+- name: Show playbooks
+  ansible.builtin.debug:
+    msg: "include_file_names: {{ include_file_names }}"
     verbosity: 1
 
 ######## END: Get playbooks to run ########
 
 
 ######## START: Execution part ########
-- name: "include tasks"
-  include_tasks: "include-file.yml"
+- name: Include tasks
+  ansible.builtin.include_tasks: include-file.yml
   loop_control:
-    loop_var: include_file_name 
+    loop_var: include_file_name
   with_items:
     - "{{ include_file_names }}"
 ######## END: Execution part ########

--- a/tasks/shared/01_run_on_all_systems.yml
+++ b/tasks/shared/01_run_on_all_systems.yml
@@ -1,10 +1,11 @@
 ---
-- debug: 
-    msg: 
-    - "This is an example task file for tasks/shared/01_run_on_all_systems.yml"
-    - "You can delete that safely"
-    - "mandatory_default_var1xxx: {{ mandatory_default_var1xxx }}"
-    - "default_var2_xxx: {{ default_var2_xxx }}"
-    - "fixed_var1: {{ fixed_var1 }}"
-    - "This is the end of the debug message"
+- name: Show shared example variables
+  ansible.builtin.debug:
+    msg:
+      - "This is an example task file for tasks/shared/01_run_on_all_systems.yml"
+      - "You can delete it safely"
+      - "mandatory_default_var1xxx: {{ mandatory_default_var1xxx }}"
+      - "default_var2_xxx: {{ default_var2_xxx }}"
+      - "fixed_var1: {{ fixed_var1 }}"
+      - "This is the end of the debug message"
 ...

--- a/tasks/shared/10_prep.yml
+++ b/tasks/shared/10_prep.yml
@@ -1,3 +1,5 @@
 ---
-- debug: msg="This is an example task file for tasks/shared/10_prep.yml"
+- name: Show shared prep example
+  ansible.builtin.debug:
+    msg: This is an example task file for tasks/shared/10_prep.yml
 ...

--- a/tasks/shared/20_setup.yml
+++ b/tasks/shared/20_setup.yml
@@ -1,3 +1,5 @@
 ---
-- debug: msg="This is an example task file for tasks/shared/20_setup.yml"
+- name: Show shared setup example
+  ansible.builtin.debug:
+    msg: This is an example task file for tasks/shared/20_setup.yml
 ...

--- a/tasks/shared/30_post.yml
+++ b/tasks/shared/30_post.yml
@@ -1,3 +1,5 @@
 ---
-- debug: msg="This is an example task file for tasks/shared/30_post.yml"
+- name: Show shared post example
+  ansible.builtin.debug:
+    msg: This is an example task file for tasks/shared/30_post.yml
 ...

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,1 +1,1 @@
-Put all templates here, that will generate a file locally
+Put Jinja2 templates here when files must be rendered on the target host.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,2 +1,21 @@
-# content move
-The Ansible installers has moved to: https://github.com/joe-speedboat/linux.scripts/tree/master/ansible
+# Tests
+
+Installer scripts moved to:
+
+<https://github.com/joe-speedboat/linux.scripts/tree/master/ansible>
+
+## Local role-template syntax check
+
+Run the test playbook from a harness directory with both the Galaxy role name and
+repository basename symlinked. The dispatcher searches for
+`roles/{{ role_path | basename }}/tasks`, which can resolve to `ansible.template`
+when the checkout directory has that name.
+
+```bash
+rm -rf /tmp/hermes-ansible-template-harness
+mkdir -p /tmp/hermes-ansible-template-harness/roles
+ln -sfn "$PWD" /tmp/hermes-ansible-template-harness/roles/joe-speedboat.template
+ln -sfn "$PWD" /tmp/hermes-ansible-template-harness/roles/ansible.template
+cd /tmp/hermes-ansible-template-harness
+ANSIBLE_ROLES_PATH=roles ansible-playbook /path/to/ansible.template/tests/test.yml -i localhost, -c local --syntax-check
+```

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,9 +1,9 @@
-#!/usr/bin/ansible-playbook 
+#!/usr/bin/ansible-playbook
 ---
-- name: joe-speedboat.template Setup
+- name: joe-speedboat.template setup
   hosts: localhost
   vars:
     mandatory_var: mandatory-value
   roles:
-    - joe-speedboat.template
+    - role: joe-speedboat.template
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,6 @@
+# vars/main.yml
 ---
-# Here belong all variables, that can be changed by a vars-file,
-# a playbook or a include.
+# Put fixed internal variables, maps, and constants here.
 
 fixed_var1: this_fixed_var_is_defined_in_vars_folder
-
 ...


### PR DESCRIPTION
## Summary
- simplify the role template README and align the documented folder fallback order with the dispatcher
- modernize example tasks/handlers to use FQCN modules and clearer task names
- collapse the rhelAll fact setup into one equivalent set_fact task
- document the local harness symlink requirement for dispatcher tests

## Validation
- `python3 - <<'PY' ... yaml.safe_load_all(...) ... PY` → `yaml ok`
- `ANSIBLE_ROLES_PATH=roles ansible-playbook /home/hermes/work/ansible.template/tests/test.yml -i localhost, -c local --syntax-check` → passed
- `ANSIBLE_ROLES_PATH=roles ansible-playbook /home/hermes/work/ansible.template/tests/test.yml -i localhost, -c local` → `ok=20 changed=0 failed=0`
- `git diff --check` → passed

`ansible-lint` was not installed in this environment, so it was skipped.