### PR TITLE
Make role template easier to adopt and maintain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,67 @@
 # Bitbull Ansible Role Template
 
-## Why
+This repository is a reusable Ansible role template for OS-aware roles. It keeps
+execution order deterministic while selecting the best task implementation for
+each target host from Ansible facts.
 
-This repository is a reusable Ansible role template for roles that need clear,
-dynamic OS-specific task dispatching while staying compatible with AWX.
+The template is intended for both humans and AI agents: keep the dispatcher
+files stable, replace the demo task files with real role logic, and document the
+role-specific variables and validation commands.
 
-The template is designed to make role maintenance easier by keeping task order
-stable and selecting the best matching implementation from Ansible facts.
+## Start a new role from this template
 
-## How it works
+1. Copy or generate a new repository named `ansible.<role_name>`.
+2. Update `meta/main.yml`:
+   - `role_name: <role_name>`
+   - `description:`
+   - `platforms:`
+   - `galaxy_tags:`
+3. Update `tests/test.yml` to use the final Galaxy role name:
+   - `joe-speedboat.<role_name>`
+4. Replace the demo variables:
+   - `defaults/main.yml` for user-overridable variables
+   - `vars/main.yml` for fixed internal maps and constants
+5. Replace or remove all demo task files:
+   - `tasks/shared/01_run_on_all_systems.yml`
+   - `tasks/shared/10_prep.yml`
+   - `tasks/shared/20_setup.yml`
+   - `tasks/shared/30_post.yml`
+   - `tasks/Rocky-8/20_setup.yml`
+   - `tasks/Rocky-8/30_post.yml`
+   - `tasks/Rocky-9/10_prep.yml`
+6. Keep `.gitstay` files only for empty task folders you want to preserve.
+7. Replace `handlers/main.yml` with real handlers or an empty handler file.
+8. Put static files in `files/` and Jinja2 templates in `templates/`.
+9. Rewrite this README for the real role: purpose, variables, examples,
+   supported OSes, and validation steps.
+10. Run the test harness from `tests/README.md` before publishing.
 
-The dispatcher in `tasks/main.yml`:
+## Do not change lightly
 
-1. Sets `ansible_distribution_combine` to `rhelAll` for RHEL-like distributions
-   (`AlmaLinux`, `Rocky`, `RedHat`) and to `dummy` for all other systems.
-2. Finds all task files below `tasks/` whose filename matches
-   `^[0-9]{2}_.*.yml$`.
-3. Deduplicates task basenames and sorts them by filename.
-4. Includes each basename once through `tasks/include-file.yml`.
+These two files are the template dispatcher contract:
 
-For every task basename, `tasks/include-file.yml` uses the first existing file
-from this order:
+- `tasks/main.yml` discovers task basenames and includes them in sorted order.
+- `tasks/include-file.yml` chooses the first existing OS-specific implementation
+  for each basename.
+
+Change them only when you intentionally change the template behavior. Normal
+role work belongs in numbered task files below `tasks/shared/`,
+`tasks/rhelAll/`, `tasks/Ubuntu/`, `tasks/Rocky-9/`, and similar folders.
+
+## How task dispatch works
+
+`tasks/main.yml` discovers every task file matching this pattern below
+`tasks/`:
+
+```text
+^[0-9]{2}_.*.yml$
+```
+
+It reduces the result to unique basenames, sorts them, and includes each
+basename once through `tasks/include-file.yml`.
+
+For each basename, `tasks/include-file.yml` uses the first existing file from
+this order:
 
 ```text
 tasks/{{ ansible_distribution }}-{{ ansible_distribution_version }}/<task>.yml
@@ -33,49 +74,77 @@ tasks/{{ ansible_os_family }}/<task>.yml
 tasks/shared/<task>.yml
 ```
 
-Examples:
+`ansible_distribution_combine` is `rhelAll` for `AlmaLinux`, `Rocky`, and
+`RedHat`; otherwise it is `dummy`.
 
-- `tasks/Rocky-9/10_prep.yml` overrides `tasks/rhelAll/10_prep.yml` and
-  `tasks/shared/10_prep.yml` on Rocky Linux 9 hosts.
-- `tasks/rhelAll/20_setup.yml` can be used for common AlmaLinux, Rocky Linux,
-  and Red Hat Enterprise Linux logic.
-- `tasks/Ubuntu/20_setup.yml` can be used for Ubuntu-specific logic.
-- `tasks/shared/30_post.yml` is the final fallback when no OS-specific file
-  exists for the same basename.
+## Folder naming rules
 
-## Example layout
+Use the most general folder that is still correct:
+
+| Folder | Use for |
+|---|---|
+| `tasks/shared/` | Logic that must run on every supported OS. |
+| `tasks/rhelAll/` | Common AlmaLinux, Rocky, and Red Hat logic. |
+| `tasks/rhelAll-8/` | RHEL-like version-specific overrides, for example Python compatibility workarounds. |
+| `tasks/Ubuntu/` | Ubuntu-specific logic. |
+| `tasks/Debian/` | Debian-family logic when it is safe for Ubuntu too. |
+| `tasks/Rocky-9/` | Distribution/version-specific overrides. |
+
+Do not use `tasks/RedHat/` as the normal abstraction for all RHEL-like systems;
+use `tasks/rhelAll/` for that.
+
+## Task file rules
+
+- Use two-digit numeric prefixes: `10_prep.yml`, `20_setup.yml`, `30_post.yml`.
+- Keep the same basename in multiple folders when you want OS-specific
+  implementations of the same step.
+- Put common work that must always run under its own basename, for example
+  `05_validate.yml`, so it is not shadowed by an OS-specific `10_prep.yml`.
+- End YAML files with `...`.
+- Prefer `ansible.builtin.*` fully qualified module names.
+- Use clear task names that describe the effect, not just the module.
+
+Example:
 
 ```text
-tasks/shared/01_run_on_all_systems.yml
-
-tasks/Rocky-9/10_prep.yml
-tasks/shared/10_prep.yml
-
-tasks/Rocky-8/20_setup.yml
-tasks/shared/20_setup.yml
-
-tasks/Rocky-8/30_post.yml
-tasks/shared/30_post.yml
+tasks/shared/05_validate.yml
+tasks/rhelAll/10_install.yml
+tasks/Ubuntu/10_install.yml
+tasks/shared/20_configure.yml
+tasks/shared/30_service.yml
 ```
 
-Numeric prefixes define execution order. The same basename can exist in multiple
-OS folders; only the first matching implementation is included for a host.
+## Basename shadowing example
 
-## Drawback
+If these files exist:
 
-Conditional grouping still has to be implemented inside the selected task file
-when several tasks need to be wrapped in the same `block`.
+```text
+tasks/rhelAll/20_setup.yml
+tasks/Ubuntu/20_setup.yml
+tasks/shared/20_setup.yml
+```
 
-## Role skeleton
+then RHEL-like and Ubuntu hosts do **not** run `tasks/shared/20_setup.yml`.
+They run only the first OS-specific match. Move shared logic to another
+basename such as `tasks/shared/15_common.yml` or `tasks/shared/25_configure.yml`.
 
-After copying this template for a real role, update at least:
+## Files and directories
 
-- `meta/main.yml` (`role_name`, description, supported platforms)
-- `defaults/main.yml` (user-overridable variables)
-- `vars/main.yml` (fixed internal variables)
-- `tasks/*` (replace the example debug tasks)
-- `handlers/main.yml` (replace the example service handler)
-- `tests/test.yml` (use the final Galaxy role name)
+| Path | Purpose |
+|---|---|
+| `defaults/main.yml` | User-overridable variables. Document every public variable in the role README. |
+| `vars/main.yml` | Fixed internal maps/constants that users normally should not override. |
+| `handlers/main.yml` | Handlers notified by tasks, for example service restart/reload. |
+| `files/` | Static files copied unchanged with `ansible.builtin.copy`. |
+| `templates/` | Jinja2 templates rendered with `ansible.builtin.template`. |
+| `tests/test.yml` | Minimal syntax/runtime smoke test for the template dispatcher. |
+| `tests/README.md` | Local harness instructions. |
+
+## Requirements
+
+- Ansible 2.9 or higher
+- Fact gathering enabled before this role runs, so `ansible_distribution`,
+  `ansible_distribution_major_version`, and `ansible_os_family` are available
 
 ## Installation
 
@@ -83,19 +152,21 @@ After copying this template for a real role, update at least:
 ansible-galaxy install joe-speedboat.template
 ```
 
-## Requirements
+## Validation
 
-- Ansible 2.9 or higher
-- A supported Linux distribution for the role generated from this template
+Use the harness documented in `tests/README.md`. Do not run only from the role
+checkout; the dispatcher expects the role to be installed below a `roles/`
+directory, as it is in normal Ansible/AWX usage.
 
-## Role variables
+At minimum run:
 
-Document user-overridable variables in `defaults/main.yml`. Keep fixed internal
-maps and constants in `vars/main.yml`.
+```bash
+ANSIBLE_ROLES_PATH=roles ansible-playbook /path/to/ansible.template/tests/test.yml -i localhost, -c local --syntax-check
+ANSIBLE_ROLES_PATH=roles ansible-playbook /path/to/ansible.template/tests/test.yml -i localhost, -c local
+```
 
-## Dependencies
-
-This template has no role dependencies.
+For a real role, add target-host tests, idempotency checks, and independent
+verification of the changes the role is supposed to make.
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,9 @@
 # defaults/main.yml
 ---
-# Put variables here when users may override them from inventory, playbooks,
-# AWX surveys, or extra-vars.
+# User-overridable variables belong here.
+# Replace these demo variables when creating a real role and document every
+# public variable in README.md.
 
-mandatory_default_var1xxx: playbook-will-fail-without-this-var
-default_var2_xxx: this_is_defined_in_defaults_folder
+template_required_value: change-me
+template_example_enabled: true
 ...

--- a/files/README.md
+++ b/files/README.md
@@ -1,1 +1,2 @@
-Put static files here when they can be copied unchanged.
+Static files copied unchanged with `ansible.builtin.copy` belong here.
+Remove this README when real files make the directory self-explanatory.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,11 @@
 # handlers/main.yml
 ---
-# Put restart, reload, and other notified actions here.
+# Add real handlers here and notify them from task files.
+# Remove this demo handler when creating a real role.
 
-- name: Restart <SERVICE>
+- name: Restart demo service
   ansible.builtin.service:
-    name: <SERVICE>
+    name: demo-service
     state: restarted
+  listen: restart demo service
 ...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,11 +1,11 @@
 # meta/main.yml
 ---
-# Change as needed.
+# Update this metadata when creating a real role.
 galaxy_info:
   author: Chris Ruettimann
+  namespace: joe_speedboat
   role_name: template
-  # namespace: joe-speedboat
-  description: Bitbull Template Ansible Role
+  description: Bitbull OS-aware Ansible role template
   min_ansible_version: '2.9'
   license: GPLv3
   platforms:
@@ -13,7 +13,13 @@ galaxy_info:
       versions:
         - '7'
         - '8'
-  galaxy_tags: []
+        - '9'
+    - name: Ubuntu
+      versions:
+        - all
+  galaxy_tags:
+    - ansible
+    - template
 
 dependencies: []
 ...

--- a/tasks/Rocky-8/20_setup.yml
+++ b/tasks/Rocky-8/20_setup.yml
@@ -1,5 +1,5 @@
 ---
-- name: Show Rocky 8 setup example
+- name: Show Rocky 8 setup demo task
   ansible.builtin.debug:
-    msg: This is an example task file for tasks/Rocky-8/20_setup.yml
+    msg: Replace tasks/Rocky-8/20_setup.yml with Rocky 8 specific setup tasks, or delete it to use a fallback.
 ...

--- a/tasks/Rocky-8/30_post.yml
+++ b/tasks/Rocky-8/30_post.yml
@@ -1,5 +1,5 @@
 ---
-- name: Show Rocky 8 post example
+- name: Show Rocky 8 post demo task
   ansible.builtin.debug:
-    msg: This is an example task file for tasks/Rocky-8/30_post.yml
+    msg: Replace tasks/Rocky-8/30_post.yml with Rocky 8 specific final tasks, or delete it to use a fallback.
 ...

--- a/tasks/Rocky-9/10_prep.yml
+++ b/tasks/Rocky-9/10_prep.yml
@@ -1,5 +1,5 @@
 ---
-- name: Show Rocky 9 prep example
+- name: Show Rocky 9 prep demo task
   ansible.builtin.debug:
-    msg: This is an example task file for tasks/Rocky-9/10_prep.yml
+    msg: Replace tasks/Rocky-9/10_prep.yml with Rocky 9 specific preparation tasks, or delete it to use a fallback.
 ...

--- a/tasks/include-file.yml
+++ b/tasks/include-file.yml
@@ -3,26 +3,19 @@
   ansible.builtin.include_tasks: "{{ include_file_path }}"
   with_first_found:
     - files:
-        # Order example for Rocky 9 / RHEL 9:
-        # tasks/Rocky-9.0                tasks/RedHat-9.0
-        # tasks/Rocky-9                  tasks/RedHat-9
-        # tasks/Rocky                    tasks/RedHat
-        # tasks/rhelAll-9.0              tasks/rhelAll-9.0
-        # tasks/rhelAll-9                tasks/rhelAll-9
-        # tasks/rhelAll                  tasks/rhelAll
-        # tasks/RedHat                   tasks/RedHat -> only useful for Debian-like fallbacks
-        # tasks/shared                   tasks/shared
-        # Regular facts are matched first, e.g. Rocky-9, RedHat-9, or AlmaLinux-9.
-        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
-        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
-        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution }}/{{ include_file_name }}"
-        # ansible_distribution_combine covers Rocky, RedHat, and AlmaLinux with one rhelAll folder.
-        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
-        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
-        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_distribution_combine }}/{{ include_file_name }}"
-        # If all OS-specific matches fail, fall back to OS family and then shared tasks.
-        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/{{ ansible_os_family }}/{{ include_file_name }}"
-        - "{{ vars['task_dir_' + role_name | split('.') | last] }}/shared/{{ include_file_name }}"
+        # Most specific distribution/version match first.
+        - "{{ role_task_dir }}/{{ ansible_distribution }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
+        - "{{ role_task_dir }}/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
+        - "{{ role_task_dir }}/{{ ansible_distribution }}/{{ include_file_name }}"
+
+        # Shared RHEL-compatible fallback for AlmaLinux, Rocky, and Red Hat.
+        - "{{ role_task_dir }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
+        - "{{ role_task_dir }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
+        - "{{ role_task_dir }}/{{ ansible_distribution_combine }}/{{ include_file_name }}"
+
+        # Generic OS-family fallback, then global fallback.
+        - "{{ role_task_dir }}/{{ ansible_os_family }}/{{ include_file_name }}"
+        - "{{ role_task_dir }}/shared/{{ include_file_name }}"
   loop_control:
     loop_var: include_file_path
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,24 +1,17 @@
 # tasks/main.yml
 ---
-######## START: Get playbooks to run ########
-
-- name: Create combined distribution fact for RHEL-compatible systems
+- name: Set distribution fallback folder
   ansible.builtin.set_fact:
     ansible_distribution_combine: "{{ 'rhelAll' if ansible_distribution in ['AlmaLinux', 'Rocky', 'RedHat'] else 'dummy' }}"
 
-- name: Fix ansible_python_interpreter for Rocky and AlmaLinux, see lib/ansible/config/base.yml
-  block:
-    - name: rhelClone v9
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: /usr/bin/python3
-      when: ansible_distribution_major_version | int == 9
-  when: ansible_distribution in ['AlmaLinux', 'Rocky']
-
-- name: Initialize include file list
+- name: Use system Python on Rocky and AlmaLinux 9
   ansible.builtin.set_fact:
-    include_file_names: []
+    ansible_python_interpreter: /usr/bin/python3
+  when:
+    - ansible_distribution in ['AlmaLinux', 'Rocky']
+    - ansible_distribution_major_version | int == 9
 
-- name: Find role directory (AWX aware)
+- name: Find this role's tasks directory
   ansible.builtin.find:
     paths:
       - /runner/requirements_roles
@@ -39,18 +32,27 @@
   register: found_task_dirs
   no_log: true
 
-- name: Show tasks directory var
-  ansible.builtin.debug:
-    msg: "{{ 'task_dir_' + role_name | split('.') | last }}: {{ found_task_dirs.files[0].path | dirname }}"
-    verbosity: 1
+- name: Fail when this role's tasks directory was not found
+  ansible.builtin.fail:
+    msg: >-
+      Could not locate tasks/main.yml for role {{ role_name }}. Install the role
+      below a supported Ansible/AWX roles path or run tests from a harness that
+      symlinks roles/{{ role_path | basename }} to this checkout.
+  when: found_task_dirs.files | length == 0
 
-- name: Define tasks directory
+- name: Store this role's tasks directory
   ansible.builtin.set_fact:
+    role_task_dir: "{{ found_task_dirs.files[0].path | dirname }}"
     "{{ 'task_dir_' + role_name | split('.') | last }}": "{{ found_task_dirs.files[0].path | dirname }}"
 
-- name: Find all task files with numeric pattern
+- name: Show this role's tasks directory
+  ansible.builtin.debug:
+    msg: "role_task_dir: {{ role_task_dir }}"
+    verbosity: 1
+
+- name: Find numbered task files
   ansible.builtin.find:
-    paths: "{{ vars['task_dir_' + role_name | split('.') | last] }}"
+    paths: "{{ role_task_dir }}"
     recurse: true
     depth: 2
     file_type: file
@@ -61,32 +63,24 @@
   run_once: true
   register: found_playbooks
 
-- name: Trim all playbook paths
+- name: Build ordered task basename list
   ansible.builtin.set_fact:
-    include_file_names: "{{ include_file_names + [plays.path | regex_replace('.*/', '')] }}"
-  loop: "{{ found_playbooks.files }}"
-  loop_control:
-    loop_var: plays
-  no_log: true
+    include_file_names: >-
+      {{ found_playbooks.files
+         | map(attribute='path')
+         | map('basename')
+         | unique
+         | sort
+         | list }}
 
-- name: Sort and deduplicate playbooks
-  ansible.builtin.set_fact:
-    include_file_names: "{{ include_file_names | unique | sort }}"
-
-- name: Show playbooks
+- name: Show ordered task basename list
   ansible.builtin.debug:
     msg: "include_file_names: {{ include_file_names }}"
     verbosity: 1
 
-######## END: Get playbooks to run ########
-
-
-######## START: Execution part ########
-- name: Include tasks
+- name: Include selected task implementation for each basename
   ansible.builtin.include_tasks: include-file.yml
+  loop: "{{ include_file_names }}"
   loop_control:
     loop_var: include_file_name
-  with_items:
-    - "{{ include_file_names }}"
-######## END: Execution part ########
 ...

--- a/tasks/shared/01_run_on_all_systems.yml
+++ b/tasks/shared/01_run_on_all_systems.yml
@@ -1,11 +1,11 @@
 ---
-- name: Show shared example variables
+- name: Show global demo task context
   ansible.builtin.debug:
     msg:
-      - "This is an example task file for tasks/shared/01_run_on_all_systems.yml"
-      - "You can delete it safely"
-      - "mandatory_default_var1xxx: {{ mandatory_default_var1xxx }}"
-      - "default_var2_xxx: {{ default_var2_xxx }}"
-      - "fixed_var1: {{ fixed_var1 }}"
-      - "This is the end of the debug message"
+      - "Demo task: tasks/shared/01_run_on_all_systems.yml"
+      - "This file runs on every host because no OS-specific file has this basename."
+      - "Replace or delete this demo file when creating a real role."
+      - "template_required_value: {{ template_required_value }}"
+      - "template_example_enabled: {{ template_example_enabled }}"
+      - "template_internal_example: {{ template_internal_example }}"
 ...

--- a/tasks/shared/10_prep.yml
+++ b/tasks/shared/10_prep.yml
@@ -1,5 +1,5 @@
 ---
-- name: Show shared prep example
+- name: Show shared prep demo task
   ansible.builtin.debug:
-    msg: This is an example task file for tasks/shared/10_prep.yml
+    msg: Replace tasks/shared/10_prep.yml with preparation tasks that run on all supported hosts.
 ...

--- a/tasks/shared/20_setup.yml
+++ b/tasks/shared/20_setup.yml
@@ -1,5 +1,5 @@
 ---
-- name: Show shared setup example
+- name: Show shared setup demo task
   ansible.builtin.debug:
-    msg: This is an example task file for tasks/shared/20_setup.yml
+    msg: Replace tasks/shared/20_setup.yml with setup tasks that run when no OS-specific 20_setup.yml exists.
 ...

--- a/tasks/shared/30_post.yml
+++ b/tasks/shared/30_post.yml
@@ -1,5 +1,5 @@
 ---
-- name: Show shared post example
+- name: Show shared post demo task
   ansible.builtin.debug:
-    msg: This is an example task file for tasks/shared/30_post.yml
+    msg: Replace tasks/shared/30_post.yml with final tasks that run when no OS-specific 30_post.yml exists.
 ...

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,1 +1,3 @@
-Put Jinja2 templates here when files must be rendered on the target host.
+Jinja2 templates rendered with `ansible.builtin.template` belong here.
+Use `.j2` suffixes and document the variables each template expects.
+Remove this README when real templates make the directory self-explanatory.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,21 +1,44 @@
 # Tests
 
-Installer scripts moved to:
+This template must be tested like an installed role. The dispatcher searches for
+`roles/{{ role_path | basename }}/tasks`, so direct execution from the checkout
+can fail even when the role itself is valid.
 
-<https://github.com/joe-speedboat/linux.scripts/tree/master/ansible>
+## Local harness
 
-## Local role-template syntax check
-
-Run the test playbook from a harness directory with both the Galaxy role name and
-repository basename symlinked. The dispatcher searches for
-`roles/{{ role_path | basename }}/tasks`, which can resolve to `ansible.template`
-when the checkout directory has that name.
+Create a temporary harness with both common role names symlinked:
 
 ```bash
 rm -rf /tmp/hermes-ansible-template-harness
 mkdir -p /tmp/hermes-ansible-template-harness/roles
-ln -sfn "$PWD" /tmp/hermes-ansible-template-harness/roles/joe-speedboat.template
-ln -sfn "$PWD" /tmp/hermes-ansible-template-harness/roles/ansible.template
+ln -sfn /path/to/ansible.template /tmp/hermes-ansible-template-harness/roles/joe-speedboat.template
+ln -sfn /path/to/ansible.template /tmp/hermes-ansible-template-harness/roles/ansible.template
 cd /tmp/hermes-ansible-template-harness
-ANSIBLE_ROLES_PATH=roles ansible-playbook /path/to/ansible.template/tests/test.yml -i localhost, -c local --syntax-check
 ```
+
+Run syntax and smoke tests:
+
+```bash
+ANSIBLE_ROLES_PATH=roles ansible-playbook /path/to/ansible.template/tests/test.yml -i localhost, -c local --syntax-check
+ANSIBLE_ROLES_PATH=roles ansible-playbook /path/to/ansible.template/tests/test.yml -i localhost, -c local
+```
+
+Expected smoke-test result for the unmodified template:
+
+```text
+failed=0
+```
+
+Warnings about missing AWX/system role paths are acceptable in this local
+harness as long as the symlinked role path is found and the play finishes with
+`failed=0`.
+
+## When creating a real role
+
+After copying the template:
+
+1. Replace `joe-speedboat.template` in `tests/test.yml` with the final role name.
+2. Update the symlink names above to match the new role and repository basename.
+3. Add real host tests for the supported OS matrix.
+4. Run idempotency checks; the second run should report no unexpected changes.
+5. Verify effects independently, not only by Ansible recap.

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,9 +1,8 @@
 #!/usr/bin/ansible-playbook
 ---
-- name: joe-speedboat.template setup
+- name: Smoke test joe-speedboat.template
   hosts: localhost
-  vars:
-    mandatory_var: mandatory-value
+  gather_facts: true
   roles:
     - role: joe-speedboat.template
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,7 @@
 # vars/main.yml
 ---
-# Put fixed internal variables, maps, and constants here.
+# Fixed internal variables, maps, and constants belong here.
+# Users normally should not override values from vars/main.yml.
 
-fixed_var1: this_fixed_var_is_defined_in_vars_folder
+template_internal_example: defined-in-vars
 ...


### PR DESCRIPTION
## Summary
- make the README usable as a start guide for humans and AI agents
- document exactly which demo task files to replace/remove when creating a real role
- simplify `tasks/main.yml` by deriving the ordered basename list directly from `find` results
- keep a clearer `role_task_dir` fact and add an explicit failure message when the role path cannot be found
- clarify `include-file.yml`, test harness instructions, defaults/vars/handlers stubs, and demo task messages
- add explicit Galaxy metadata namespace so ansible-lint can validate the role

## Advice for starting a real role from this template
1. Copy the template to `ansible.<role_name>`.
2. Update `meta/main.yml` and `tests/test.yml` with the final role name.
3. Replace or delete all demo task files under `tasks/shared/`, `tasks/Rocky-8/`, and `tasks/Rocky-9/`.
4. Keep only task folders that represent real supported OS paths.
5. Document variables in `defaults/main.yml`, keep constants in `vars/main.yml`, and add real target-host validation beyond this smoke test.

## Validation
- YAML parse over all `*.yml`: `yaml ok`
- Harness syntax check: passed
- Harness smoke run: `ok=18 changed=0 failed=0`
- `git diff --check origin/master..HEAD`: passed
- `uvx --from ansible-lint ansible-lint .`: `Passed: 0 failure(s), 0 warning(s)`
