### PR TITLE
Keep dispatcher variables role-scoped

### DIFF
--- a/tasks/include-file.yml
+++ b/tasks/include-file.yml
@@ -1,21 +1,23 @@
 ---
 - name: Include {{ include_file_name }}
   ansible.builtin.include_tasks: "{{ include_file_path }}"
+  vars:
+    selected_role_task_dir: "{{ vars['task_dir_' + role_name | split('.') | last] }}"
   with_first_found:
     - files:
         # Most specific distribution/version match first.
-        - "{{ role_task_dir }}/{{ ansible_distribution }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
-        - "{{ role_task_dir }}/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
-        - "{{ role_task_dir }}/{{ ansible_distribution }}/{{ include_file_name }}"
+        - "{{ selected_role_task_dir }}/{{ ansible_distribution }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
+        - "{{ selected_role_task_dir }}/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
+        - "{{ selected_role_task_dir }}/{{ ansible_distribution }}/{{ include_file_name }}"
 
         # Shared RHEL-compatible fallback for AlmaLinux, Rocky, and Red Hat.
-        - "{{ role_task_dir }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
-        - "{{ role_task_dir }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
-        - "{{ role_task_dir }}/{{ ansible_distribution_combine }}/{{ include_file_name }}"
+        - "{{ selected_role_task_dir }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_version }}/{{ include_file_name }}"
+        - "{{ selected_role_task_dir }}/{{ ansible_distribution_combine }}-{{ ansible_distribution_major_version }}/{{ include_file_name }}"
+        - "{{ selected_role_task_dir }}/{{ ansible_distribution_combine }}/{{ include_file_name }}"
 
         # Generic OS-family fallback, then global fallback.
-        - "{{ role_task_dir }}/{{ ansible_os_family }}/{{ include_file_name }}"
-        - "{{ role_task_dir }}/shared/{{ include_file_name }}"
+        - "{{ selected_role_task_dir }}/{{ ansible_os_family }}/{{ include_file_name }}"
+        - "{{ selected_role_task_dir }}/shared/{{ include_file_name }}"
   loop_control:
     loop_var: include_file_path
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,19 +40,18 @@
       symlinks roles/{{ role_path | basename }} to this checkout.
   when: found_task_dirs.files | length == 0
 
-- name: Store this role's tasks directory
+- name: Store this role's tasks directory in a role-scoped fact
   ansible.builtin.set_fact:
-    role_task_dir: "{{ found_task_dirs.files[0].path | dirname }}"
     "{{ 'task_dir_' + role_name | split('.') | last }}": "{{ found_task_dirs.files[0].path | dirname }}"
 
 - name: Show this role's tasks directory
   ansible.builtin.debug:
-    msg: "role_task_dir: {{ role_task_dir }}"
+    msg: "{{ 'task_dir_' + role_name | split('.') | last }}: {{ vars['task_dir_' + role_name | split('.') | last] }}"
     verbosity: 1
 
 - name: Find numbered task files
   ansible.builtin.find:
-    paths: "{{ role_task_dir }}"
+    paths: "{{ vars['task_dir_' + role_name | split('.') | last] }}"
     recurse: true
     depth: 2
     file_type: file
@@ -63,9 +62,9 @@
   run_once: true
   register: found_playbooks
 
-- name: Build ordered task basename list
+- name: Build ordered task basename list in a role-scoped fact
   ansible.builtin.set_fact:
-    include_file_names: >-
+    "{{ 'include_file_names_' + role_name | split('.') | last }}": >-
       {{ found_playbooks.files
          | map(attribute='path')
          | map('basename')
@@ -75,12 +74,12 @@
 
 - name: Show ordered task basename list
   ansible.builtin.debug:
-    msg: "include_file_names: {{ include_file_names }}"
+    msg: "{{ 'include_file_names_' + role_name | split('.') | last }}: {{ vars['include_file_names_' + role_name | split('.') | last] }}"
     verbosity: 1
 
 - name: Include selected task implementation for each basename
   ansible.builtin.include_tasks: include-file.yml
-  loop: "{{ include_file_names }}"
+  loop: "{{ vars['include_file_names_' + role_name | split('.') | last] }}"
   loop_control:
     loop_var: include_file_name
 ...


### PR DESCRIPTION
## Summary
- restore role-scoped dispatcher facts for task-directory and task-basename state
- remove persistent generic `role_task_dir` and `include_file_names` facts from `tasks/main.yml`
- keep `include-file.yml` path lookup based on the dynamic `task_dir_<role>` fact
- use only a task-local helper variable in `include-file.yml` to keep long path expressions readable

## Why
Template-derived roles can include other template-derived roles. Persistent generic facts such as `role_task_dir` can be overwritten by the nested role and then break the parent role's remaining dispatcher loop. The role-specific fact names (`task_dir_<role>` and `include_file_names_<role>`) avoid that collision.

## Validation
- no persisted generic dispatcher facts in `tasks/main.yml`
- YAML parse over all `*.yml`: `yaml ok`
- harness syntax check: passed
- harness smoke run: `ok=18 changed=0 failed=0`
- `git diff --check`: passed
- `uvx --from ansible-lint ansible-lint .`: `Passed: 0 failure(s), 0 warning(s)`
